### PR TITLE
Editorial: minor algorithm style cleanup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,8 +220,8 @@ interaction, even if only the **first URL value** is currently exposed in the
 Infrastructure Algorithms {#sec-infra-algos}
 -----------------
 
-<div algorithm="get current interaction context">
-  To <dfn>get current interaction context</dfn> for a [=Document=] |document|, run the following steps:
+<div algorithm>
+  To <dfn>get the current interaction context</dfn> given a [=Document=] |document|:
 
   1. Let |context| be the value of the internal `AsyncContext.Variable`
      `[[ActiveInteractionContext]]`.
@@ -230,9 +230,9 @@ Infrastructure Algorithms {#sec-infra-algos}
   1. Return |context|.
 </div>
 
-<div algorithm="get or create context for interaction">
-  To <dfn>get or create context for interaction</dfn>, given a [=Document=] |document|, an
-  |interaction id|, and an [=Event=] |event|, run the following steps:
+<div algorithm>
+  To <dfn>get the context for an interaction</dfn> given a [=Document=] |document|, an
+  |interaction id|, and an [=Event=] |event|:
 
   1. If |document|'s [=interaction id to interaction context=][|interaction id|] [=map/exists=],
      return |document|'s [=interaction id to interaction context=][|interaction id|].
@@ -245,9 +245,9 @@ Infrastructure Algorithms {#sec-infra-algos}
   1. Return |interaction context|.
 </div>
 
-<div algorithm="update interaction contexts for event">
-  To <dfn>update interaction contexts for event</dfn>, given a [=Document=] |document| and an
-  [=Event=] |event|, run the following steps:
+<div algorithm>
+  To <dfn>update the interaction contexts for an event</dfn> given a [=Document=] |document| and an
+  [=Event=] |event|:
 
   1. Let |timestamp| be the [=current high resolution time=] given |document|'s [=relevant global object=].
   1. Let |is scroll| be true if |event|'s type is "scroll", and false otherwise.
@@ -264,25 +264,25 @@ Infrastructure Algorithms {#sec-infra-algos}
       1. Set |interaction context|'s [=InteractionContext/first input timestamp=] to |timestamp|.
 </div>
 
-<div algorithm="set current interaction context for event dispatch">
-  To <dfn>set current interaction context for event dispatch</dfn>, given null or a
-  {{PerformanceEventTiming}} object |timingEntry|, run the following steps:
+<div algorithm>
+  To <dfn>set the current interaction context for event dispatch</dfn> given null or a
+  {{PerformanceEventTiming}} object |timingEntry|:
 
   1. If |timingEntry| is null, return null.
   1. Let |event| be |timingEntry|'s [=associated event=].
   1. Let |interaction id| be |timingEntry|'s {{PerformanceEventTiming/interactionId}}.
   1. If |interaction id| is null or 0, return null.
   1. Let |document| be |event|'s [=relevant global object=]'s [=associated Document=].
-  1. [=update interaction contexts for event=] given |document| and |event|.
-  1. Let |interaction context| be the result of [=get or create context for interaction=] given
+  1. [=Update the interaction contexts for an event=] given |document| and |event|.
+  1. Let |interaction context| be the result of [=geting the context for an interaction=] given
      |document|, |interaction id|, and |event|.
   1. Set the value of the internal `AsyncContext.Variable` `[[ActiveInteractionContext]]` to
      |interaction context|.
   1. Return |interaction context|.
 </div>
 
-<div algorithm="unset current interaction context after event dispatch">
-  To <dfn>unset current interaction context after event dispatch</dfn>, run the following steps:
+<div algorithm>
+  To <dfn>unset the current interaction context after event dispatch</dfn>:
 
   1. Set the value of the internal `AsyncContext.Variable` `[[ActiveInteractionContext]]` to null.
 </div>
@@ -340,10 +340,10 @@ ensure these metrics reflect the exact state of that visual update.
 Interaction Contentful Paint Algorithms {#sec-interaction-contentful-paint-algos}
 -----------------
 
-<div algorithm="create an interaction contentful paint entry">
-  To <dfn>create an interaction contentful paint entry</dfn>, with a [=/global object=] |global|, an
+<div algorithm>
+  To <dfn>create an interaction contentful paint entry</dfn>, given a [=/global object=] |global|, an
   [=InteractionContext=] |interaction context|, a {{LargestContentfulPaint}} |lcpEntry|, and a
-  [=paint timing info=] |paintTimingInfo|, run the following steps:
+  [=paint timing info=] |paintTimingInfo|:
 
   1. Let |entry| be a new {{InteractionContentfulPaint}} object in |global|'s [=global object/realm=].
   1. Set |entry|'s [=InteractionContentfulPaint/context=] to |interaction context|.
@@ -352,10 +352,10 @@ Interaction Contentful Paint Algorithms {#sec-interaction-contentful-paint-algos
   1. Return |entry|.
 </div>
 
-<div algorithm="process a new attributed contentful paint candidate">
-  To <dfn>process a new attributed contentful paint candidate</dfn>, given a
+<div algorithm>
+  To <dfn>process a new attributed contentful paint candidate</dfn> given a
   {{LargestContentfulPaint}} |lcpEntry|, a [=Document=] |document|, and an [=InteractionContext=]
-  |interaction context|, run the following steps:
+  |interaction context|:
 
   1. If |interaction context|'s [=InteractionContext/first scroll timestamp=] is set and
      |lcpEntry|'s {{LargestContentfulPaint/renderTime}} is greater than |interaction context|'s
@@ -448,9 +448,9 @@ conditions:
  * A same-document URL change occurs while an [=InteractionContext=] is active.
  * A contentful paint occurs that is attributed to the same [=InteractionContext=].
 
-<div algorithm="evaluate soft navigation emission">
-  To <dfn>evaluate soft navigation emission</dfn>, given a [=Document=] |document| and an
-  [=InteractionContext=] |interaction context|, run the following steps:
+<div algorithm>
+  To <dfn>evaluate soft navigation emission</dfn> given a [=Document=] |document| and an
+  [=InteractionContext=] |interaction context|:
 
   1. If |interaction context|'s [=InteractionContext/emitted=] is true, return.
   1. If |document|'s [=document/active soft navigation candidate=] is not |interaction context|, return.
@@ -458,13 +458,13 @@ conditions:
   1. If |interaction context|'s [=InteractionContext/first contentful paint=] is null, return.
   1. Let |global| be |document|'s [=relevant global object=].
   1. Let |entry| be the result of [=create a soft navigation entry=] given |global| and |interaction context|.
-  1. [=emit soft navigation entry=] given |global| and |entry|.
+  1. [=Emit a soft navigation entry=] given |global| and |entry|.
   1. Set |interaction context|'s [=InteractionContext/emitted=] to true.
 </div>
 
-<div algorithm="create a soft navigation entry">
-  To <dfn>create a soft navigation entry</dfn>, with a [=/global object=] |global|, and an
-  [=InteractionContext=] |interaction context|, run the following steps:
+<div algorithm>
+  To <dfn>create a soft navigation entry</dfn> given a [=/global object=] |global|, and an
+  [=InteractionContext=] |interaction context|:
 
   1. Let |entry| be a new {{PerformanceSoftNavigation}} object in |global|'s [=global object/realm=].
   1. Set |entry|'s [=PerformanceSoftNavigation/context=] to |interaction context|.
@@ -476,9 +476,9 @@ conditions:
 
 Note: `navigationId` is set further down, in [=queue a PerformanceEntry=].
 
-<div algorithm="emit soft navigation entry">
-  To <dfn>emit soft navigation entry</dfn>, with a [=/global object=] |global|, and a
-  {{PerformanceSoftNavigation}} |entry|, run the following steps:
+<div algorithm>
+  To <dfn>emit a soft navigation entry</dfn> given a [=/global object=] |global| and a
+  {{PerformanceSoftNavigation}} |entry|:
 
   1. Set |entry|'s [=PerformanceEntry/navigation id=] to |entry|'s {{PerformanceSoftNavigation/interactionId}}.
   1. Set |global|'s [=global object/current navigation id=] to |entry|'s {{PerformanceSoftNavigation/interactionId}}.
@@ -486,12 +486,13 @@ Note: `navigationId` is set further down, in [=queue a PerformanceEntry=].
   1. Add |entry| to |global|'s [=performance entry buffer=].
 </div>
 
-<div algorithm="process same document commit">
-  To <dfn>process same document commit</dfn>, with a [=Document=] |document|, [=string=] |url|,
-  and [=string=] |navigation type|, run the following steps:
+<div algorithm>
+  To <dfn>process a same document commit</dfn> given a [=Document=] |document|, [=string=] |url|,
+  and [=string=] |navigation type|:
 
   1. If |url| is equal to |document|'s [=Document/url=], return.
-  1. Let |interaction context| be the result of [=get current interaction context=] given |document|.
+  1. Let |interaction context| be the result of [=getting the current interaction context=] given
+     |document|.
   1. If |interaction context| is null, return.
   1. Set |interaction context|'s [=InteractionContext/last URL value=] to |url|.
   1. If |interaction context|'s [=InteractionContext/first URL update timestamp=] is unset:
@@ -500,7 +501,7 @@ Note: `navigationId` is set further down, in [=queue a PerformanceEntry=].
     1. Set |interaction context|'s [=InteractionContext/first URL value=] to |url|.
     1. Set |interaction context|'s [=InteractionContext/navigation type=] to |navigation type|.
   1. Set |document|'s [=document/active soft navigation candidate=] to |interaction context|.
-  1. [=evaluate soft navigation emission=] given |document| and |interaction context|.
+  1. [=Evaluate soft navigation emission=] given |document| and |interaction context|.
 </div>
 
 
@@ -539,13 +540,13 @@ Each [=document=] has an <dfn for=document>active soft navigation candidate</dfn
 
 <div algorithm="additions to history step application">
   In [=update document for history step application=], before 5.5.1 (if `documentsEntryChanged` is
-  true and if `documentIsNew` is false), [=process same document commit=] given the [=Document=],
+  true and if `documentIsNew` is false), [=process a same document commit=] given the [=Document=],
   the target entry's [=session history entry url|url=], and "traverse".
 </div>
 
 <div algorithm="additions to shared history push/replace steps">
   In the [shared history push/replace steps](https://html.spec.whatwg.org/multipage/nav-history-apis.html#shared-history-push/replace-steps)
-  (as defined in [[HTML]]), after the URL is updated, [=process same document commit=] given the
+  (as defined in [[HTML]]), after the URL is updated, [=process a same document commit=] given the
   [=Document=], the new URL, and the operation type (either "push" or "replace").
 </div>
 
@@ -576,9 +577,9 @@ The following event types are considered to be part of an [=interaction=] (as de
   * `hashchange`
 
 When these events are dispatched as a result of a user interaction, the user agent must assign them
-a unique [=interaction id=] obtained by running the steps to [=get the next interactionId=] for the
-document's [=relevant global object=]. If an event is triggered by a previous interaction that
-already has an assigned [=interaction id=], the user agent should reuse that same identifier.
+a unique [=interaction id=] obtained by [=getting the next interactionId=] for the document's
+[=relevant global object=]. If an event is triggered by a previous interaction that already has an
+assigned [=interaction id=], the user agent should reuse that same identifier.
 
 Note:These events are only reported as primary interactions when they are the initiating event from
 a user action (e.g., clicking the browser UI's back button). In most other scenarios—such as a
@@ -603,7 +604,7 @@ Issue: This specification uses `unsigned long long` for **interactionId** to ens
 counter, while [[EVENT-TIMING]] currently defines it as `unsigned long`. This mismatch is expected
 to be resolved in future versions of both specifications.
 
-<div algorithm="get the next interactionId">
+<div algorithm>
   To <dfn>get the next interactionId</dfn> for a {{Window}} |window|:
 
   1. Set |window|'s [=interaction count=] to |window|'s [=interaction count=] plus 1.
@@ -616,9 +617,9 @@ to be resolved in future versions of both specifications.
 
   1. Right after the step that sets |timingEntry| to the result of [=initialize and record event
      timing processing start=], run the following step:
-    1. [=set current interaction context for event dispatch=] given |timingEntry|.
+    1. [=Set the current interaction context for event dispatch=] given |timingEntry|.
   1. Right before the step that calls [=record event timing processing end=], run the following step:
-    1. [=unset current interaction context after event dispatch=].
+    1. [=Unset the current interaction context after event dispatch=].
 </div>
 
 Largest Contentful Paint (LCP) integration {#sec-lcp-integration}
@@ -646,9 +647,9 @@ This specification hooks into the [[LARGEST-CONTENTFUL-PAINT]] algorithm to attr
       1. [=map/Set=] |contextToNewLargestCandidate|[|interaction context|] to |candidate|.
   1. For each |interaction context| → |newLcpCandidate| in |contextToNewLargestCandidate|:
     1. Let |newLcpEntry| be the {{LargestContentfulPaint}} entry representing |newLcpCandidate|.
-    1. [=process a new attributed contentful paint candidate=] given |newLcpEntry|, |document|, and
+    1. [=Process a new attributed contentful paint candidate=] given |newLcpEntry|, |document|, and
        |interaction context|.
-    1. [=evaluate soft navigation emission=] given |document| and |interaction context|.
+    1. [=Evaluate soft navigation emission=] given |document| and |interaction context|.
 </div>
 
 Note: The [[#sec-container-timing-integration]] section defines how modifications to the DOM reset
@@ -676,7 +677,8 @@ user interactions.
   Run the following steps:
 
   1. Let |document| be the node's [=Node/node document=].
-  1. Let |interaction context| be the result of [=get current interaction context=] given |document|.
+  1. Let |interaction context| be the result of [=getting the current interaction context=] given
+     |document|.
   1. If |interaction context| is not null:
     1. Set the node's [=node/associated interaction context=] to |interaction context|.
     1. Designate the node as a **container root** (as defined in [[CONTAINER-TIMING]]).


### PR DESCRIPTION
- Use more complete sentences in algo names to improve readability (e.g. "get the current" vs. "get current").
 - Fix some conjugation (e.g. use "getting" instead of "get" where applicable). Bikeshed mostly handles this. I changed  "get or create" to just "get" to make the conjugation easier since I think the meaning was still clear enough.
 - Fix a few sentence casing issues, upper-casing algo invocations at the beginnings of sentences.
 - Remove names for explicit `<div algorithm="name">` where they aren't needed, i.e. where we're defining exactly one algorithm, since Bikeshed handles.
 - Align algorithm declarations with https://infra.spec.whatwg.org/#algorithm-declaration. I used the short form for everything since I thought the return type was obvious for algorithms with return values.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/soft-navigations/pull/77.html" title="Last updated on Jun 3, 2026, 4:11 PM UTC (f935b9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/soft-navigations/77/5146785...shaseley:f935b9a.html" title="Last updated on Jun 3, 2026, 4:11 PM UTC (f935b9a)">Diff</a>