### PR TITLE
Update LCP spec URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -53,7 +53,7 @@ urlPrefix: https://www.w3.org/TR/css-view-transitions-1/
   type: dfn; text: startViewTransition(); url: #dom-document-startviewtransition;
 urlPrefix: https://w3c.github.io/performance-timeline/; spec: PERFORMANCE-TIMELINE
   type: dfn; text: queue a PerformanceEntry; url: #dfn-queue-a-performanceentry;
-urlPrefix: https://pr-preview.s3.amazonaws.com/shaseley/largest-contentful-paint/pull/171.html; spec: LARGEST-CONTENTFUL-PAINT
+urlPrefix: https://w3c.github.io/largest-contentful-paint/; spec: LARGEST-CONTENTFUL-PAINT
   type: dfn;
     text: has dispatched scroll event; url: #has-dispatched-scroll-event;
     text: report largest contentful paint; url: #report-largest-contentful-paint;


### PR DESCRIPTION
Update the LCP URL now that https://github.com/w3c/largest-contentful-paint/pull/171 has landed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/soft-navigations/pull/89.html" title="Last updated on Jul 13, 2026, 10:14 PM UTC (073ab30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/soft-navigations/89/5b0c0e4...shaseley:073ab30.html" title="Last updated on Jul 13, 2026, 10:14 PM UTC (073ab30)">Diff</a>